### PR TITLE
Ease the use of the gem and allow to run pdf.render manually

### DIFF
--- a/dinbrief.gemspec
+++ b/dinbrief.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_development_dependency "prawn", "1.0.0.rc1"
-  # s.add_runtime_dependency "rest-client"
+  s.add_runtime_dependency "prawn", "~>2.0.2"
+  s.add_runtime_dependency 'prawn-table'
+
 end

--- a/lib/dinbrief.rb
+++ b/lib/dinbrief.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'prawn'
+require 'prawn/table'
 require 'prawn/measurement_extensions'
 
 module Dinbrief

--- a/lib/dinbrief/letter.rb
+++ b/lib/dinbrief/letter.rb
@@ -6,15 +6,20 @@ module Dinbrief
 
     def self.letter(pdf_or_filename, options={}, &block)
       case pdf_or_filename
-      when Dinbrief::Letter
-        make_letter(pdf_or_filename, &block)
-        pdf_or_filename
-      when Prawn::Document
-        raise "Give an instance of Dinbrief::Letter to letter method."
-      when String
-        self.generate(pdf_or_filename, DocumentDefaults.merge(options)) do |pdf|
-          make_letter(pdf, &block)
-        end
+        when Dinbrief::Letter
+          make_letter(pdf_or_filename, &block)
+          pdf_or_filename
+        when Prawn::Document
+          raise "Give an instance of Dinbrief::Letter to letter method."
+        when String
+          self.generate(pdf_or_filename, DocumentDefaults.merge(options)) do |pdf|
+            make_letter(pdf, &block)
+          end
+        when nil
+          letter = self.new(DocumentDefaults.merge(options)) do |pdf|
+            make_letter(pdf, &block)
+          end
+          return letter
       end
     end
 

--- a/lib/dinbrief/version.rb
+++ b/lib/dinbrief/version.rb
@@ -1,3 +1,3 @@
 module Dinbrief
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
New feature:

``` ruby
  @letter = MyLetter.letter(nil) do |db|
    ...
  end
  def render
    @letter.render
  end
```

also update the used version of prawn and require the dependant gems automatically
